### PR TITLE
Improve flow agent exploration heuristics

### DIFF
--- a/docs/flow_agent/all_docs/components/mcts_core.md
+++ b/docs/flow_agent/all_docs/components/mcts_core.md
@@ -11,6 +11,7 @@ Main classes
   - `max_sims`, `max_time_s`: Budgets for number of simulations and wall-clock time.
   - `commit_eval_limit`: Legacy limiter for commit evaluation calls; effective limit is by `max_sims` and caching.
   - `priors_temperature`: Softmax temperature for priors (when applied).
+  - `min_unique_commit_evals`: Forces extra RateFinder probes until this many unique commit signatures have been evaluated.
   - `phi_scale`: Scales potential shaping signal.
   - `seed`: RNG seed for stable tie-breaking.
 - `TreeNode`: Node statistics and structure.
@@ -37,8 +38,10 @@ How it works
   - `select_flows`: `AddFlow` for not-yet-selected candidates, `RemoveFlow` for selected, `Continue` if any selected, plus `Stop`.
   - `confirm`: `CommitRegulation`, `Back`, `Stop`.
 - `_compute_priors(...)`: Scores actions using hotspot and flow metadata.
-  - `AddFlow`: Sums the flow’s proxy histogram (proportional to entrants in window).
+  - `AddFlow`: Uses log1p(sum(proxy histogram)) to flatten extreme entrant counts.
   - `PickHotspot`: Reads `hotspot_prior` from candidate payloads and normalizes.
+  - Dirichlet noise: Blends exploration noise into root priors, the first `select_hotspot`, and the first `select_flows` node to prevent early collapse.
+  - Extra commit seeding: when unique RateFinder evaluations are scarce, the search synthesizes additional flow combinations to populate the cache.
 
 3) Commit caching and best commit
 - `_commit_eval_cache`: Memoizes `(rates, delta_j, info)` by a signature of the selected flows and hotspot window.

--- a/docs/flow_agent/all_docs/mcts_overview.md
+++ b/docs/flow_agent/all_docs/mcts_overview.md
@@ -96,6 +96,11 @@ Parameters for the MCTS search itself.
 -   `max_time_s: float`: Maximum time in seconds for a search.
 -   `commit_eval_limit: int`: A budget for how many times the expensive `RateFinder` can be called per search.
 -   `priors_temperature: float`: Controls the sharpness of the softmax for priors.
+    Higher default values (≈4.0) flatten the action distribution before applying exploration noise.
+-   `root_dirichlet_epsilon: float`, `root_dirichlet_alpha: float`: Amount of Dirichlet noise blended into root priors each search (defaults ≈0.25 and 0.3).
+-   `hotspot_dirichlet_epsilon: float`, `hotspot_dirichlet_alpha: float`: Similar noise applied to the first hotspot-selection node (defaults ≈0.3 and 0.5).
+-   `flow_dirichlet_epsilon: float`, `flow_dirichlet_alpha: float`: Optional noise for the first flow-selection node to diversify early choices (defaults ≈0.3 and 0.4).
+-   `min_unique_commit_evals: int`: Forces extra RateFinder probes until this many unique commit signatures have been evaluated, reducing premature convergence.
 -   `phi_scale: float`: Scaling factor for the potential shaping reward.
 -   `seed: int`: RNG seed for reproducibility.
 


### PR DESCRIPTION
## Summary
- raise default exploration settings (c_puct, priors_temperature, Dirichlet noise, min_unique_commit_evals) and inject Dirichlet noise at root, hotspot, and flow selection nodes while flattening AddFlow priors
- introduce forced exploration when the commit cache is sparse and seed extra RateFinder evaluations to hit the minimum unique commit target
- document the new configuration defaults, noise behaviour, and commit seeding across the MCTS docs

## Testing
- python examples/flow_agent/run_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f9013328832b8517bcfb8f93c9dc