### PR TITLE
Ensure regen test bench proposes fallback regulation

### DIFF
--- a/src/parrhesia/flow_agent/mcts.py
+++ b/src/parrhesia/flow_agent/mcts.py
@@ -398,8 +398,20 @@ class MCTS:
                 self._dbg(f"[MCTS/expand] create_leaf node={key[:24]}… phi={float(node.phi):.3f} {self._state_brief(state)}")
                 v = -node.phi
                 self._dbg(f"[MCTS/simulate] leaf_bootstrap return={float(v):.3f} {self._state_brief(state)} path_len={len(path)}")
-        self._log_backup_path(path, v, sim_index=sim_index, step_index=step_index, reason="leaf_bootstrap")
-        self._backup(path, v, sim_index=sim_index, step_index=step_index, reason="leaf_bootstrap")
+                self._log_backup_path(
+                    path,
+                    v,
+                    sim_index=sim_index,
+                    step_index=step_index,
+                    reason="leaf_bootstrap",
+                )
+                self._backup(
+                    path,
+                    v,
+                    sim_index=sim_index,
+                    step_index=step_index,
+                    reason="leaf_bootstrap",
+                )
                 return v
 
             candidates = self._enumerate_actions(state)
@@ -563,8 +575,20 @@ class MCTS:
                     self._dbg(
                         f"[MCTS/simulate] commit_blocked budget commits_used={commits_used}/{commit_depth} -> bootstrap={float(v):.3f}"
                     )
-            self._log_backup_path(path, v, sim_index=sim_index, step_index=step_index, reason="commit_blocked")
-            self._backup(path, v, sim_index=sim_index, step_index=step_index, reason="commit_blocked")
+                    self._log_backup_path(
+                        path,
+                        v,
+                        sim_index=sim_index,
+                        step_index=step_index,
+                        reason="commit_blocked",
+                    )
+                    self._backup(
+                        path,
+                        v,
+                        sim_index=sim_index,
+                        step_index=step_index,
+                        reason="commit_blocked",
+                    )
                     return v
                 self._dbg(
                     f"[MCTS/simulate] evaluate_commit flows={len(getattr(getattr(state, 'hotspot_context', None), 'selected_flow_ids', []) or [])} {self._state_brief(state)}"

--- a/src/parrhesia/flow_agent35/regen/rates.py
+++ b/src/parrhesia/flow_agent35/regen/rates.py
@@ -9,9 +9,11 @@ from .types import Bundle, RateCut
 
 
 def compute_e_target(D_vec: Sequence[float], *, mode: str = "q95", fallback_to_peak: bool = True) -> float:
-    if not D_vec:
+    if D_vec is None:
         return 0.0
     arr = np.asarray(D_vec, dtype=np.float64)
+    if arr.size == 0:
+        return 0.0
     if mode == "q95":
         e_target = float(np.quantile(arr, 0.95))
     elif mode == "peak":

--- a/src/project_tailwind/impact_eval/distance_computation.py
+++ b/src/project_tailwind/impact_eval/distance_computation.py
@@ -1,8 +1,8 @@
 import json
-import networkx as nx
-import numpy as np
-from typing import Dict, List, Tuple
 import warnings
+from typing import Dict, List, Tuple
+
+import numpy as np
 
 # Suppress networkx warnings for better output
 warnings.filterwarnings("ignore")
@@ -18,6 +18,13 @@ def load_route_graph(gml_path: str) -> Dict[str, Tuple[float, float]]:
     Returns:
         Dictionary mapping waypoint names to (lat, lon) tuples
     """
+    try:
+        import networkx as nx
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment guard
+        raise ModuleNotFoundError(
+            "The 'networkx' dependency is required to load route graphs."
+        ) from exc
+
     graph = nx.read_gml(gml_path)
     waypoint_coords = {}
     


### PR DESCRIPTION
## Summary
- defer the networkx import in the distance computation helper so optional users can call haversine routines without the dependency
- repair indentation in the flow-agent MCTS backup paths to avoid syntax errors
- harden e_target computation and extend the regen test bench with relaxed fallbacks and a heuristic regulation writer so it always emits a proposal

## Testing
- python examples/regen/regen_test_bench.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a5926c80832bbec7cb11a96a6b0e